### PR TITLE
Add monthly account statement feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ hs_err_pid*
 replay_pid*
 src/.DS_Store
 *.json
+out/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,9 @@
 {
     "java.project.sourcePaths": [
-        "lib",
         "src"
     ],
+    "java.project.outputPath": "out/vscode-bin",
     "java.project.referencedLibraries": [
-        "lib\\junit-platform-console-standalone-1.13.0-M3.jar",
         "test-lib\\**\\*.jar",
         "test-lib/**/*.jar"
     ]

--- a/src/main/AccountSnapshot.java
+++ b/src/main/AccountSnapshot.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 final class AccountSnapshot implements Serializable {
-    private static final long serialVersionUID = 2L;
+    private static final long serialVersionUID = 1L;
 
     private final double balance;
     private final String transactionHistory;
@@ -42,6 +42,9 @@ final class AccountSnapshot implements Serializable {
     }
 
     private void restoreTransactions(BankAccount account) {
+        if (transactions == null) {
+            return;
+        }
         for (Transaction t : transactions) {
             account.addTransactionRecord(t);
         }

--- a/src/main/AccountSnapshot.java
+++ b/src/main/AccountSnapshot.java
@@ -5,13 +5,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 final class AccountSnapshot implements Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     private final double balance;
     private final String transactionHistory;
     private final boolean frozen;
     private final double maxWithdrawAmount;
     private final List<FeeSnapshot> fees;
+    private final List<Transaction> transactions;
 
     AccountSnapshot(BankAccount account) {
         this.balance = account.getBalance();
@@ -19,6 +20,7 @@ final class AccountSnapshot implements Serializable {
         this.frozen = account.isFrozen();
         this.maxWithdrawAmount = account.getMaxWithdrawAmount();
         this.fees = toFeeSnapshots(account.getRemainingFees());
+        this.transactions = new ArrayList<>(account.getTransactions());
     }
 
     BankAccount toAccount() {
@@ -29,12 +31,19 @@ final class AccountSnapshot implements Serializable {
                 maxWithdrawAmount
         );
         restoreFees(account);
+        restoreTransactions(account);
         return account;
     }
 
     private void restoreFees(BankAccount account) {
         for (FeeSnapshot fee : fees) {
             account.createFee(fee.toFee());
+        }
+    }
+
+    private void restoreTransactions(BankAccount account) {
+        for (Transaction t : transactions) {
+            account.addTransactionRecord(t);
         }
     }
 

--- a/src/main/AccountSnapshot.java
+++ b/src/main/AccountSnapshot.java
@@ -4,7 +4,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-final class AccountSnapshot implements Serializable {
+public final class AccountSnapshot implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final double balance;
@@ -14,7 +14,7 @@ final class AccountSnapshot implements Serializable {
     private final List<FeeSnapshot> fees;
     private final List<Transaction> transactions;
 
-    AccountSnapshot(BankAccount account) {
+    public AccountSnapshot(BankAccount account) {
         this.balance = account.getBalance();
         this.transactionHistory = account.getTransactionHistory();
         this.frozen = account.isFrozen();
@@ -23,7 +23,7 @@ final class AccountSnapshot implements Serializable {
         this.transactions = new ArrayList<>(account.getTransactions());
     }
 
-    BankAccount toAccount() {
+    public BankAccount toAccount() {
         BankAccount account = new BankAccount(
                 balance,
                 transactionHistory,

--- a/src/main/BankAccount.java
+++ b/src/main/BankAccount.java
@@ -1,6 +1,7 @@
 package main;
 
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,6 +14,7 @@ public class BankAccount implements Serializable {
     private ArrayList<Fee> fees;
     private boolean frozen;
     private double maxWithdrawAmount;
+    private List<Transaction> transactions;
 
     public BankAccount() {
         this.balance = 0;
@@ -20,6 +22,7 @@ public class BankAccount implements Serializable {
         this.fees = new ArrayList<>();
         this.frozen = false;
         this.maxWithdrawAmount = Double.MAX_VALUE;
+        this.transactions = new ArrayList<>();
     }
 
     public BankAccount(double balance, String transactionHistory) {
@@ -28,6 +31,7 @@ public class BankAccount implements Serializable {
         this.fees = new ArrayList<>();
         this.frozen = false;
         this.maxWithdrawAmount = Double.MAX_VALUE;
+        this.transactions = new ArrayList<>();
     }
 
     public BankAccount(double balance, String transactionHistory, boolean frozen) {
@@ -36,6 +40,7 @@ public class BankAccount implements Serializable {
         this.fees = new ArrayList<>();
         this.frozen = frozen;
         this.maxWithdrawAmount = Double.MAX_VALUE;
+        this.transactions = new ArrayList<>();
     }
 
     public BankAccount(double balance, String transactionHistory, boolean frozen, double maxWithdrawAmount) {
@@ -44,6 +49,7 @@ public class BankAccount implements Serializable {
         this.fees = new ArrayList<>();
         this.frozen = frozen;
         this.maxWithdrawAmount = maxWithdrawAmount <= 0 ? Double.MAX_VALUE : maxWithdrawAmount;
+        this.transactions = new ArrayList<>();
     }
 
     public BankAccount(double balance, String transactionHistory, double maxWithdrawAmount) {
@@ -56,6 +62,7 @@ public class BankAccount implements Serializable {
         } else {
             this.maxWithdrawAmount = maxWithdrawAmount;
         }
+        this.transactions = new ArrayList<>();
     }
 
     public void deposit(double amount) {
@@ -63,6 +70,7 @@ public class BankAccount implements Serializable {
         if (amount > 0) {
             this.balance += amount;
             this.transactionHistory += "Deposited: " + amount + "\n";
+            this.transactions.add(new Transaction(LocalDate.now(), "Deposited: " + amount, amount));
         } else {
             throw new IllegalArgumentException("Deposit amount must be greater than 0.");
         }
@@ -72,6 +80,7 @@ public class BankAccount implements Serializable {
         if (interestAmount > 0) {
             this.balance += interestAmount;
             this.transactionHistory += "Interest added: " + interestAmount + "\n";
+            this.transactions.add(new Transaction(LocalDate.now(), "Interest added: " + interestAmount, interestAmount));
         } else {
             throw new IllegalArgumentException("Interest amount must be greater than 0.");
         }
@@ -81,6 +90,7 @@ public class BankAccount implements Serializable {
         if (feeAmount > 0) {
             this.balance -= feeAmount;
             this.transactionHistory += "Fee collected: " + feeAmount + "\n";
+            this.transactions.add(new Transaction(LocalDate.now(), "Fee collected: " + feeAmount, -feeAmount));
         } else {
             throw new IllegalArgumentException("Fee amount must be greater than 0.");
         }
@@ -104,6 +114,7 @@ public class BankAccount implements Serializable {
         }
         this.frozen = true;
         this.transactionHistory += "Account frozen.\n";
+        this.transactions.add(new Transaction(LocalDate.now(), "Account frozen", 0.0));
     }
 
     public void unfreezeAccount() {
@@ -112,6 +123,7 @@ public class BankAccount implements Serializable {
         }
         this.frozen = false;
         this.transactionHistory += "Account unfrozen.\n";
+        this.transactions.add(new Transaction(LocalDate.now(), "Account unfrozen", 0.0));
     }
 
     public double getMaxWithdrawAmount() {
@@ -125,7 +137,9 @@ public class BankAccount implements Serializable {
 
         this.maxWithdrawAmount = maxWithdrawAmount;
         this.transactionHistory += "Maximum withdrawal amount set to: " + maxWithdrawAmount + "\n";
+        this.transactions.add(new Transaction(LocalDate.now(), "Maximum withdrawal amount set to: " + maxWithdrawAmount, 0.0));
     }
+
     public void withdraw(double amount) {
         ensureAccountIsActive();
 
@@ -141,6 +155,7 @@ public class BankAccount implements Serializable {
         }
         balance -= amount;
         this.transactionHistory += "Withdrew: " + amount + "\n";
+        this.transactions.add(new Transaction(LocalDate.now(), "Withdrew: " + amount, -amount));
     }
 
     public void transferMoney(BankAccount targetAccount, double amount) {
@@ -190,11 +205,31 @@ public class BankAccount implements Serializable {
         balance -= fee.getAmount();
         fees.remove(feeIndex);
         this.transactionHistory += "Paid fee: " + fee.getAmount() + " for " + fee.getDescription() + "\n";
+        this.transactions.add(new Transaction(LocalDate.now(), "Paid fee: " + fee.getAmount() + " for " + fee.getDescription(), -fee.getAmount()));
     }
 
     public List<Fee> getRemainingFees() {
         return new ArrayList<>(this.fees);
     }
+
+    public List<Transaction> getTransactions() {
+        return new ArrayList<>(this.transactions);
+    }
+
+    public List<Transaction> getTransactionsByYearMonth(int year, int month) {
+        List<Transaction> result = new ArrayList<>();
+        for (Transaction t : this.transactions) {
+            if (t.getDate().getYear() == year && t.getDate().getMonthValue() == month) {
+                result.add(t);
+            }
+        }
+        return result;
+    }
+
+    void addTransactionRecord(Transaction t) {
+        this.transactions.add(t);
+    }
+
     private void ensureAccountIsActive() {
         if (this.frozen) {
             throw new IllegalStateException("This account is frozen. Transactions are not allowed.");

--- a/src/main/BankAccount.java
+++ b/src/main/BankAccount.java
@@ -69,8 +69,7 @@ public class BankAccount implements Serializable {
         ensureAccountIsActive();
         if (amount > 0) {
             this.balance += amount;
-            this.transactionHistory += "Deposited: " + amount + "\n";
-            this.transactions.add(new Transaction(LocalDate.now(), "Deposited: " + amount, amount));
+            recordTransaction("Deposited: " + amount, amount);
         } else {
             throw new IllegalArgumentException("Deposit amount must be greater than 0.");
         }
@@ -79,8 +78,7 @@ public class BankAccount implements Serializable {
     public void addInterest(double interestAmount) {
         if (interestAmount > 0) {
             this.balance += interestAmount;
-            this.transactionHistory += "Interest added: " + interestAmount + "\n";
-            this.transactions.add(new Transaction(LocalDate.now(), "Interest added: " + interestAmount, interestAmount));
+            recordTransaction("Interest added: " + interestAmount, interestAmount);
         } else {
             throw new IllegalArgumentException("Interest amount must be greater than 0.");
         }
@@ -89,8 +87,7 @@ public class BankAccount implements Serializable {
     public void collectFee(double feeAmount) {
         if (feeAmount > 0) {
             this.balance -= feeAmount;
-            this.transactionHistory += "Fee collected: " + feeAmount + "\n";
-            this.transactions.add(new Transaction(LocalDate.now(), "Fee collected: " + feeAmount, -feeAmount));
+            recordTransaction("Fee collected: " + feeAmount, -feeAmount);
         } else {
             throw new IllegalArgumentException("Fee amount must be greater than 0.");
         }
@@ -113,8 +110,7 @@ public class BankAccount implements Serializable {
             throw new IllegalStateException("This account is already frozen.");
         }
         this.frozen = true;
-        this.transactionHistory += "Account frozen.\n";
-        this.transactions.add(new Transaction(LocalDate.now(), "Account frozen", 0.0));
+        recordTransaction("Account frozen.", 0.0);
     }
 
     public void unfreezeAccount() {
@@ -122,8 +118,7 @@ public class BankAccount implements Serializable {
             throw new IllegalStateException("This account is not frozen.");
         }
         this.frozen = false;
-        this.transactionHistory += "Account unfrozen.\n";
-        this.transactions.add(new Transaction(LocalDate.now(), "Account unfrozen", 0.0));
+        recordTransaction("Account unfrozen.", 0.0);
     }
 
     public double getMaxWithdrawAmount() {
@@ -136,8 +131,7 @@ public class BankAccount implements Serializable {
         }
 
         this.maxWithdrawAmount = maxWithdrawAmount;
-        this.transactionHistory += "Maximum withdrawal amount set to: " + maxWithdrawAmount + "\n";
-        this.transactions.add(new Transaction(LocalDate.now(), "Maximum withdrawal amount set to: " + maxWithdrawAmount, 0.0));
+        recordTransaction("Maximum withdrawal amount set to: " + maxWithdrawAmount, 0.0);
     }
 
     public void withdraw(double amount) {
@@ -154,8 +148,7 @@ public class BankAccount implements Serializable {
             throw new IllegalArgumentException("Insufficient funds.");
         }
         balance -= amount;
-        this.transactionHistory += "Withdrew: " + amount + "\n";
-        this.transactions.add(new Transaction(LocalDate.now(), "Withdrew: " + amount, -amount));
+        recordTransaction("Withdrew: " + amount, -amount);
     }
 
     public void transferMoney(BankAccount targetAccount, double amount) {
@@ -204,8 +197,7 @@ public class BankAccount implements Serializable {
 
         balance -= fee.getAmount();
         fees.remove(feeIndex);
-        this.transactionHistory += "Paid fee: " + fee.getAmount() + " for " + fee.getDescription() + "\n";
-        this.transactions.add(new Transaction(LocalDate.now(), "Paid fee: " + fee.getAmount() + " for " + fee.getDescription(), -fee.getAmount()));
+        recordTransaction("Paid fee: " + fee.getAmount() + " for " + fee.getDescription(), -fee.getAmount());
     }
 
     public List<Fee> getRemainingFees() {
@@ -227,7 +219,15 @@ public class BankAccount implements Serializable {
     }
 
     void addTransactionRecord(Transaction t) {
+        if (t == null) {
+            throw new IllegalArgumentException("Transaction cannot be null.");
+        }
         this.transactions.add(t);
+    }
+
+    private void recordTransaction(String description, double amount) {
+        this.transactionHistory += description + "\n";
+        this.transactions.add(new Transaction(LocalDate.now(), description, amount));
     }
 
     private void ensureAccountIsActive() {

--- a/src/main/BankSnapshot.java
+++ b/src/main/BankSnapshot.java
@@ -4,16 +4,16 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-final class BankSnapshot implements Serializable {
+public final class BankSnapshot implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final List<CustomerSnapshot> customers;
 
-    BankSnapshot(Bank bank) {
+    public BankSnapshot(Bank bank) {
         this.customers = toCustomerSnapshots(bank.getCustomers());
     }
 
-    Bank toBank() {
+    public Bank toBank() {
         Bank bank = new Bank();
         for (CustomerSnapshot customer : customers) {
             bank.addCustomer(customer.toCustomer());

--- a/src/main/CustomerAccessPortal.java
+++ b/src/main/CustomerAccessPortal.java
@@ -2,7 +2,7 @@ package main;
 
 import java.util.Scanner;
 
-final class CustomerAccessPortal {
+public final class CustomerAccessPortal {
     private static final int LOGIN_SELECTION = 1;
     private static final int REGISTER_SELECTION = 2;
     private static final int BACK_SELECTION = 3;
@@ -15,7 +15,7 @@ final class CustomerAccessPortal {
     private final CustomerAuthenticator authenticator;
     private final CustomerRegistrationService registrationService;
 
-    CustomerAccessPortal(Bank bank, Scanner keyboardInput) {
+    public CustomerAccessPortal(Bank bank, Scanner keyboardInput) {
         this.bank = bank;
         this.keyboardInput = keyboardInput;
         this.io = new MenuInput(keyboardInput);
@@ -23,7 +23,7 @@ final class CustomerAccessPortal {
         this.registrationService = new CustomerRegistrationService(bank);
     }
 
-    void run() {
+    public void run() {
         int selection = -1;
         while (selection != BACK_SELECTION) {
             displayOptions();

--- a/src/main/CustomerAccountSelector.java
+++ b/src/main/CustomerAccountSelector.java
@@ -2,14 +2,14 @@ package main;
 
 import java.util.List;
 
-final class CustomerAccountSelector {
+public final class CustomerAccountSelector {
     private final MenuInput io;
 
-    CustomerAccountSelector(MenuInput io) {
+    public CustomerAccountSelector(MenuInput io) {
         this.io = io;
     }
 
-    BankAccount selectAccount(Customer customer, String action) {
+    public BankAccount selectAccount(Customer customer, String action) {
         List<BankAccount> accounts = customer.getAccounts();
         if (accounts.isEmpty()) {
             throw new IllegalStateException("No accounts available to " + action + ".");

--- a/src/main/CustomerAuthenticator.java
+++ b/src/main/CustomerAuthenticator.java
@@ -1,21 +1,21 @@
 package main;
 
-final class CustomerAuthenticator {
+public final class CustomerAuthenticator {
     private final Bank bank;
 
-    CustomerAuthenticator(Bank bank) {
+    public CustomerAuthenticator(Bank bank) {
         this.bank = bank;
     }
 
-    Customer findCustomer(String email) {
+    public Customer findCustomer(String email) {
         return bank.findCustomerByEmail(email);
     }
 
-    boolean isPasswordValid(Customer customer, String password) {
+    public boolean isPasswordValid(Customer customer, String password) {
         return customer != null && customer.verifyPassword(password);
     }
 
-    boolean isPinValid(Customer customer, String pin) {
+    public boolean isPinValid(Customer customer, String pin) {
         return customer != null && customer.verifyPin(pin);
     }
 }

--- a/src/main/CustomerCredentials.java
+++ b/src/main/CustomerCredentials.java
@@ -2,44 +2,44 @@ package main;
 
 import java.io.Serializable;
 
-final class CustomerCredentials implements Serializable {
+public final class CustomerCredentials implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String password;
     private String pin;
 
-    CustomerCredentials() {
+    public CustomerCredentials() {
     }
 
-    CustomerCredentials(String password, String pin) {
+    public CustomerCredentials(String password, String pin) {
         this.password = password;
         this.pin = pin;
     }
 
-    void setPassword(String password) {
+    public void setPassword(String password) {
         this.password = requireValue(password, "Password");
     }
 
-    void setPin(String pin) {
+    public void setPin(String pin) {
         if (pin == null || !pin.matches("\\d{4}")) {
             throw new IllegalArgumentException("PIN must be exactly 4 digits.");
         }
         this.pin = pin;
     }
 
-    boolean verifyPassword(String password) {
+    public boolean verifyPassword(String password) {
         return this.password != null && this.password.equals(password);
     }
 
-    boolean verifyPin(String pin) {
+    public boolean verifyPin(String pin) {
         return this.pin != null && this.pin.equals(pin);
     }
 
-    String getStoredPassword() {
+    public String getStoredPassword() {
         return password;
     }
 
-    String getStoredPin() {
+    public String getStoredPin() {
         return pin;
     }
 

--- a/src/main/CustomerMenu.java
+++ b/src/main/CustomerMenu.java
@@ -6,8 +6,8 @@ import java.util.Scanner;
 public class CustomerMenu {
 
     private static final int DASHBOARD_OPTION_COUNT = 5;
-    private static final int ACCOUNT_MENU_EXIT_SELECTION = 9;
-    private static final int ACCOUNT_MENU_MAX_SELECTION = 9;
+    private static final int ACCOUNT_MENU_EXIT_SELECTION = 10;
+    private static final int ACCOUNT_MENU_MAX_SELECTION = 10;
 
     protected final Scanner keyboardInput;
     protected final Bank bank;
@@ -221,6 +221,10 @@ public class CustomerMenu {
         }
     }
 
+    public void viewMonthlyStatement(BankAccount account) {
+        new MonthlyStatementViewer(keyboardInput, account).viewMonthlyStatement();
+    }
+
     public void manageRecurringPayments() {
         new RecurringPaymentMenu(keyboardInput, customer).run();
     }
@@ -271,8 +275,9 @@ public class CustomerMenu {
         System.out.println("5. Transfer money from this account");
         System.out.println("6. Set maximum withdrawal amount");
         System.out.println("7. Pay a pending fee");
-        System.out.println("8. Close this account");
-        System.out.println("9. Back to account dashboard");
+        System.out.println("8. View monthly statement");
+        System.out.println("9. Close this account");
+        System.out.println("10. Back to account dashboard");
     }
 
     private boolean processAccountSelection(BankAccount account, int selection) {
@@ -284,7 +289,8 @@ public class CustomerMenu {
             case 5: transferBetweenAccounts(account); return false;
             case 6: setMaximumWithdrawalAmount(account); return false;
             case 7: payPendingFee(account); return false;
-            case 8:
+            case 8: viewMonthlyStatement(account); return false;
+            case 9:
                 closeExistingAccount(account);
                 return !customer.getAccounts().contains(account);
             case ACCOUNT_MENU_EXIT_SELECTION:

--- a/src/main/CustomerProfile.java
+++ b/src/main/CustomerProfile.java
@@ -2,7 +2,7 @@ package main;
 
 import java.io.Serializable;
 
-final class CustomerProfile implements Serializable {
+public final class CustomerProfile implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final String name;
@@ -10,34 +10,34 @@ final class CustomerProfile implements Serializable {
     private String phoneNumber;
     private String email;
 
-    CustomerProfile(String name) {
+    public CustomerProfile(String name) {
         this.name = requireValue(name, "Name");
     }
 
-    CustomerProfile(String name, String address, String phoneNumber, String email) {
+    public CustomerProfile(String name, String address, String phoneNumber, String email) {
         this(name);
         this.address = address;
         this.phoneNumber = phoneNumber;
         this.email = email;
     }
 
-    String getName() {
+    public String getName() {
         return name;
     }
 
-    String getAddress() {
+    public String getAddress() {
         return address;
     }
 
-    String getPhoneNumber() {
+    public String getPhoneNumber() {
         return phoneNumber;
     }
 
-    String getEmail() {
+    public String getEmail() {
         return email;
     }
 
-    void updatePersonalInformation(String address, String phoneNumber, String email) {
+    public void updatePersonalInformation(String address, String phoneNumber, String email) {
         this.address = requireValue(address, "Address");
         this.phoneNumber = requireValue(phoneNumber, "Phone number");
         this.email = requireValue(email, "Email");

--- a/src/main/CustomerRegistrationRequest.java
+++ b/src/main/CustomerRegistrationRequest.java
@@ -1,6 +1,6 @@
 package main;
 
-final class CustomerRegistrationRequest {
+public final class CustomerRegistrationRequest {
     private final String name;
     private final String address;
     private final String phoneNumber;
@@ -8,7 +8,7 @@ final class CustomerRegistrationRequest {
     private final String password;
     private final String pin;
 
-    CustomerRegistrationRequest(String name, String address, String phoneNumber,
+    public CustomerRegistrationRequest(String name, String address, String phoneNumber,
                                 String email, String password, String pin) {
         this.name = name;
         this.address = address;
@@ -18,27 +18,27 @@ final class CustomerRegistrationRequest {
         this.pin = pin;
     }
 
-    String getName() {
+    public String getName() {
         return name;
     }
 
-    String getAddress() {
+    public String getAddress() {
         return address;
     }
 
-    String getPhoneNumber() {
+    public String getPhoneNumber() {
         return phoneNumber;
     }
 
-    String getEmail() {
+    public String getEmail() {
         return email;
     }
 
-    String getPassword() {
+    public String getPassword() {
         return password;
     }
 
-    String getPin() {
+    public String getPin() {
         return pin;
     }
 }

--- a/src/main/CustomerRegistrationService.java
+++ b/src/main/CustomerRegistrationService.java
@@ -1,13 +1,13 @@
 package main;
 
-final class CustomerRegistrationService {
+public final class CustomerRegistrationService {
     private final Bank bank;
 
-    CustomerRegistrationService(Bank bank) {
+    public CustomerRegistrationService(Bank bank) {
         this.bank = bank;
     }
 
-    Customer register(CustomerRegistrationRequest request) {
+    public Customer register(CustomerRegistrationRequest request) {
         if (request == null) {
             throw new IllegalArgumentException("Registration request cannot be null.");
         }

--- a/src/main/CustomerSnapshot.java
+++ b/src/main/CustomerSnapshot.java
@@ -4,7 +4,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-final class CustomerSnapshot implements Serializable {
+public final class CustomerSnapshot implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final String name;
@@ -16,7 +16,7 @@ final class CustomerSnapshot implements Serializable {
     private final List<AccountSnapshot> accounts;
     private final List<RecurringPaymentSnapshot> recurringPayments;
 
-    CustomerSnapshot(Customer customer) {
+    public CustomerSnapshot(Customer customer) {
         CustomerCredentials credentials = customer.getCredentials();
         this.name = customer.getName();
         this.address = customer.getAddress();
@@ -28,7 +28,7 @@ final class CustomerSnapshot implements Serializable {
         this.recurringPayments = toPaymentSnapshots(customer.getRecurringPayments());
     }
 
-    Customer toCustomer() {
+    public Customer toCustomer() {
         return new Customer(
                 new CustomerProfile(name, address, phoneNumber, email),
                 new CustomerCredentials(password, pin),

--- a/src/main/FeeSnapshot.java
+++ b/src/main/FeeSnapshot.java
@@ -3,20 +3,20 @@ package main;
 import java.io.Serializable;
 import java.util.Date;
 
-final class FeeSnapshot implements Serializable {
+public final class FeeSnapshot implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final double amount;
     private final String description;
     private final Date dueDate;
 
-    FeeSnapshot(Fee fee) {
+    public FeeSnapshot(Fee fee) {
         this.amount = fee.getAmount();
         this.description = fee.getDescription();
         this.dueDate = fee.getDueDate();
     }
 
-    Fee toFee() {
+    public Fee toFee() {
         return new Fee(amount, description, dueDate);
     }
 }

--- a/src/main/MenuInput.java
+++ b/src/main/MenuInput.java
@@ -2,14 +2,14 @@ package main;
 
 import java.util.Scanner;
 
-final class MenuInput {
+public final class MenuInput {
     private final Scanner keyboardInput;
 
-    MenuInput(Scanner keyboardInput) {
+    public MenuInput(Scanner keyboardInput) {
         this.keyboardInput = keyboardInput;
     }
 
-    int readSelection(int max) {
+    public int readSelection(int max) {
         if (max < 1) {
             throw new IllegalArgumentException("At least one selection must be available.");
         }
@@ -25,7 +25,7 @@ final class MenuInput {
         return selection;
     }
 
-    double readPositiveAmount(String prompt) {
+    public double readPositiveAmount(String prompt) {
         double amount = -1;
         while (amount <= 0) {
             System.out.print(prompt);
@@ -38,11 +38,11 @@ final class MenuInput {
         return amount;
     }
 
-    void prepareForTextInput() {
+    public void prepareForTextInput() {
         keyboardInput.skip("\\R?");
     }
 
-    String readRequiredText(String prompt) {
+    public String readRequiredText(String prompt) {
         String value = "";
         while (value.trim().isEmpty()) {
             System.out.print(prompt);
@@ -51,7 +51,7 @@ final class MenuInput {
         return value.trim();
     }
 
-    String readPin(String prompt) {
+    public String readPin(String prompt) {
         String pin = "";
         while (!pin.matches("\\d{4}")) {
             System.out.print(prompt);

--- a/src/main/MonthlyStatementViewer.java
+++ b/src/main/MonthlyStatementViewer.java
@@ -1,7 +1,5 @@
 package main;
 
-import java.io.Serializable;
-import java.time.LocalDate;
 import java.time.Month;
 import java.util.List;
 import java.util.Scanner;
@@ -59,37 +57,5 @@ public class MonthlyStatementViewer {
         System.out.println("Total credits:  " + totalCredits);
         System.out.println("Total debits:   " + totalDebits);
         System.out.println("Net change:     " + (totalCredits - totalDebits));
-    }
-}
-
-class Transaction implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    private final LocalDate date;
-    private final String description;
-    private final double amount;
-
-    Transaction(LocalDate date, String description, double amount) {
-        this.date = date;
-        this.description = description;
-        this.amount = amount;
-    }
-
-    public LocalDate getDate() {
-        return date;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public double getAmount() {
-        return amount;
-    }
-
-    @Override
-    public String toString() {
-        return date + " | " + description + " | $" + amount;
     }
 }

--- a/src/main/MonthlyStatementViewer.java
+++ b/src/main/MonthlyStatementViewer.java
@@ -1,0 +1,95 @@
+package main;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.List;
+import java.util.Scanner;
+
+public class MonthlyStatementViewer {
+
+    private final MenuInput io;
+    private final BankAccount account;
+
+    public MonthlyStatementViewer(Scanner scanner, BankAccount account) {
+        this.io = new MenuInput(scanner);
+        this.account = account;
+    }
+
+    public void viewMonthlyStatement() {
+        io.prepareForTextInput();
+        System.out.print("Enter year (e.g., 2024): ");
+        int year;
+        try {
+            year = Integer.parseInt(io.readRequiredText("").trim());
+        } catch (NumberFormatException e) {
+            System.out.println("Invalid year.");
+            return;
+        }
+
+        System.out.println("Enter month (1-12): ");
+        int month = io.readSelection(12);
+
+        List<Transaction> transactions = account.getTransactionsByYearMonth(year, month);
+        String monthLabel = Month.of(month).name().charAt(0)
+                + Month.of(month).name().substring(1).toLowerCase()
+                + " " + year;
+
+        if (transactions.isEmpty()) {
+            System.out.println("No transactions found for " + monthLabel + ".");
+            return;
+        }
+
+        System.out.println("Statement for " + monthLabel + ":");
+        System.out.println("--------------------------------------------");
+        for (Transaction t : transactions) {
+            System.out.println(t);
+        }
+        System.out.println("--------------------------------------------");
+
+        double totalCredits = 0;
+        double totalDebits = 0;
+        for (Transaction t : transactions) {
+            if (t.getAmount() >= 0) {
+                totalCredits += t.getAmount();
+            } else {
+                totalDebits += Math.abs(t.getAmount());
+            }
+        }
+        System.out.println("Total credits:  " + totalCredits);
+        System.out.println("Total debits:   " + totalDebits);
+        System.out.println("Net change:     " + (totalCredits - totalDebits));
+    }
+}
+
+class Transaction implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final LocalDate date;
+    private final String description;
+    private final double amount;
+
+    Transaction(LocalDate date, String description, double amount) {
+        this.date = date;
+        this.description = description;
+        this.amount = amount;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    @Override
+    public String toString() {
+        return date + " | " + description + " | $" + amount;
+    }
+}

--- a/src/main/RecurringPaymentSnapshot.java
+++ b/src/main/RecurringPaymentSnapshot.java
@@ -3,7 +3,7 @@ package main;
 import java.io.Serializable;
 import java.time.LocalDate;
 
-final class RecurringPaymentSnapshot implements Serializable {
+public final class RecurringPaymentSnapshot implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final String description;
@@ -13,7 +13,7 @@ final class RecurringPaymentSnapshot implements Serializable {
     private final RecurringPayment.Frequency frequency;
     private final LocalDate nextPaymentDate;
 
-    RecurringPaymentSnapshot(RecurringPayment payment) {
+    public RecurringPaymentSnapshot(RecurringPayment payment) {
         this.description = payment.getDescription();
         this.sourceAccountIndex = payment.getSourceAccountIndex();
         this.targetAccountIndex = payment.getTargetAccountIndex();
@@ -22,7 +22,7 @@ final class RecurringPaymentSnapshot implements Serializable {
         this.nextPaymentDate = payment.getNextPaymentDate();
     }
 
-    RecurringPayment toRecurringPayment() {
+    public RecurringPayment toRecurringPayment() {
         return new RecurringPayment(
                 description,
                 sourceAccountIndex,

--- a/src/main/Transaction.java
+++ b/src/main/Transaction.java
@@ -1,0 +1,37 @@
+package main;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Objects;
+
+public final class Transaction implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final LocalDate date;
+    private final String description;
+    private final double amount;
+
+    public Transaction(LocalDate date, String description, double amount) {
+        this.date = Objects.requireNonNull(date, "date cannot be null.");
+        this.description = Objects.requireNonNull(description, "description cannot be null.");
+        this.amount = amount;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    @Override
+    public String toString() {
+        return date + " | " + description + " | $" + amount;
+    }
+}

--- a/src/test/AccountSnapshotTest.java
+++ b/src/test/AccountSnapshotTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import java.lang.reflect.Field;

--- a/src/test/AccountSnapshotTest.java
+++ b/src/test/AccountSnapshotTest.java
@@ -2,10 +2,13 @@ package main;
 
 import org.junit.Test;
 
+import java.lang.reflect.Field;
+import java.time.LocalDate;
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class AccountSnapshotTest {
@@ -24,6 +27,40 @@ public class AccountSnapshotTest {
         assertEquals(40.0, restored.getMaxWithdrawAmount(), 0.01);
         assertTrue(restored.getTransactionHistory().contains("Deposited: 75.0"));
         assertEquals("Maintenance", restored.getRemainingFees().get(0).getDescription());
+    }
+
+    @Test
+    public void testToAccountRestoresStructuredTransactions() {
+        BankAccount account = new BankAccount();
+        account.deposit(75.0);
+        account.withdraw(10.0);
+
+        BankAccount restored = new AccountSnapshot(account).toAccount();
+
+        assertEquals(
+                2,
+                restored.getTransactionsByYearMonth(LocalDate.now().getYear(), LocalDate.now().getMonthValue()).size()
+        );
+    }
+
+    @Test
+    public void testToAccountHandlesLegacySnapshotsWithoutTransactions() throws Exception {
+        BankAccount account = new BankAccount();
+        account.deposit(75.0);
+        AccountSnapshot snapshot = new AccountSnapshot(account);
+        clearTransactions(snapshot);
+
+        BankAccount restored = snapshot.toAccount();
+
+        assertNotNull(restored);
+        assertTrue(restored.getTransactionHistory().contains("Deposited: 75.0"));
+        assertTrue(restored.getTransactions().isEmpty());
+    }
+
+    private void clearTransactions(AccountSnapshot snapshot) throws Exception {
+        Field transactionsField = AccountSnapshot.class.getDeclaredField("transactions");
+        transactionsField.setAccessible(true);
+        transactionsField.set(snapshot, null);
     }
 
     private Date tomorrow() {

--- a/src/test/BankDataStoreTest.java
+++ b/src/test/BankDataStoreTest.java
@@ -67,6 +67,11 @@ public class BankDataStoreTest {
         assertEquals("Monthly fee", loadedFirstAccount.getRemainingFees().get(0).getDescription());
         assertEquals(dueDate, loadedFirstAccount.getRemainingFees().get(0).getDueDate());
         assertTrue(loadedFirstAccount.getTransactionHistory().contains("Deposited: 300.0"));
+        assertEquals(
+                1,
+                loadedFirstAccount.getTransactionsByYearMonth(LocalDate.now().getYear(), LocalDate.now().getMonthValue())
+                        .size()
+        );
 
         BankAccount loadedSecondAccount = loadedCustomer.getAccounts().get(1);
         assertTrue(loadedSecondAccount.isFrozen());

--- a/src/test/BankSnapshotTest.java
+++ b/src/test/BankSnapshotTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import java.time.LocalDate;

--- a/src/test/CustomerAccessPortalTest.java
+++ b/src/test/CustomerAccessPortalTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;

--- a/src/test/CustomerAccountSelectorTest.java
+++ b/src/test/CustomerAccountSelectorTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;

--- a/src/test/CustomerAccountSelectorTest.java
+++ b/src/test/CustomerAccountSelectorTest.java
@@ -1,0 +1,73 @@
+package main;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Scanner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class CustomerAccountSelectorTest {
+
+    @Test
+    public void testSelectAccountRejectsWhenNoAccountsAreAvailable() {
+        Customer customer = new Customer("No Accounts") {
+            @Override
+            public java.util.List<BankAccount> getAccounts() {
+                return Collections.emptyList();
+            }
+        };
+        CustomerAccountSelector selector = new CustomerAccountSelector(
+                new MenuInput(new Scanner(new ByteArrayInputStream(new byte[0])))
+        );
+
+        try {
+            selector.selectAccount(customer, "withdraw from");
+            fail();
+        } catch (IllegalStateException e) {
+            assertEquals("No accounts available to withdraw from.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSelectAccountDisplaysChoicesAndReturnsSelectedAccount() {
+        Customer customer = new Customer("Nick");
+        customer.getAccounts().get(0).deposit(10.0);
+        BankAccount secondAccount = customer.openAccount();
+        secondAccount.deposit(25.0);
+        secondAccount.createFee(new Fee(15.0, "Monthly fee", tomorrow()));
+
+        String rawInput = "2" + System.lineSeparator();
+        CustomerAccountSelector selector = new CustomerAccountSelector(
+                new MenuInput(new Scanner(new ByteArrayInputStream(rawInput.getBytes(StandardCharsets.UTF_8))))
+        );
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        try {
+            System.setOut(new PrintStream(output));
+            BankAccount selected = selector.selectAccount(customer, "review");
+
+            assertSame(secondAccount, selected);
+        } finally {
+            System.setOut(original);
+        }
+
+        String printed = output.toString();
+        assertTrue(printed.contains("Select account to review:"));
+        assertTrue(printed.contains("2. Account #2"));
+        assertTrue(printed.contains("You have 15.0 due for Monthly fee"));
+    }
+
+    private Date tomorrow() {
+        return new Date(System.currentTimeMillis() + 86400000);
+    }
+}

--- a/src/test/CustomerAuthenticatorTest.java
+++ b/src/test/CustomerAuthenticatorTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/CustomerCredentialsTest.java
+++ b/src/test/CustomerCredentialsTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/CustomerCredentialsTest.java
+++ b/src/test/CustomerCredentialsTest.java
@@ -1,0 +1,63 @@
+package main;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class CustomerCredentialsTest {
+
+    @Test
+    public void testConstructorStoresInitialValues() {
+        CustomerCredentials credentials = new CustomerCredentials("secret", "1234");
+
+        assertEquals("secret", credentials.getStoredPassword());
+        assertEquals("1234", credentials.getStoredPin());
+    }
+
+    @Test
+    public void testSetPasswordTrimsAndVerifies() {
+        CustomerCredentials credentials = new CustomerCredentials();
+        credentials.setPassword("  secret  ");
+
+        assertEquals("secret", credentials.getStoredPassword());
+        assertTrue(credentials.verifyPassword("secret"));
+        assertFalse(credentials.verifyPassword("wrong"));
+    }
+
+    @Test
+    public void testSetPasswordRejectsBlankValues() {
+        CustomerCredentials credentials = new CustomerCredentials();
+
+        try {
+            credentials.setPassword("   ");
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Password cannot be empty.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSetPinStoresAndVerifies() {
+        CustomerCredentials credentials = new CustomerCredentials();
+        credentials.setPin("4321");
+
+        assertEquals("4321", credentials.getStoredPin());
+        assertTrue(credentials.verifyPin("4321"));
+        assertFalse(credentials.verifyPin("1234"));
+    }
+
+    @Test
+    public void testSetPinRejectsInvalidValues() {
+        CustomerCredentials credentials = new CustomerCredentials();
+
+        try {
+            credentials.setPin("12a4");
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("PIN must be exactly 4 digits.", e.getMessage());
+        }
+    }
+}

--- a/src/test/CustomerDashboardMenuTest.java
+++ b/src/test/CustomerDashboardMenuTest.java
@@ -45,8 +45,7 @@ public class CustomerDashboardMenuTest {
         String input = String.join(System.lineSeparator(),
                 "1",
                 "50",
-                "9",
-                "9"
+                "10"
         ) + System.lineSeparator();
         CustomerMenu menu = new CustomerMenu(
                 new Bank(),
@@ -78,8 +77,7 @@ public class CustomerDashboardMenuTest {
         String input = String.join(System.lineSeparator(),
                 "7",
                 "1",
-                "9",
-                "9"
+                "10"
         ) + System.lineSeparator();
         CustomerMenu menu = new CustomerMenu(
                 new Bank(),

--- a/src/test/CustomerMenuEdgeCaseTest.java
+++ b/src/test/CustomerMenuEdgeCaseTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;

--- a/src/test/CustomerProfileTest.java
+++ b/src/test/CustomerProfileTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/CustomerProfileTest.java
+++ b/src/test/CustomerProfileTest.java
@@ -1,0 +1,52 @@
+package main;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class CustomerProfileTest {
+
+    @Test
+    public void testConstructorStoresInitialValues() {
+        CustomerProfile profile = new CustomerProfile("Nick", "123 Main St", "5551234567", "nick@test.com");
+
+        assertEquals("Nick", profile.getName());
+        assertEquals("123 Main St", profile.getAddress());
+        assertEquals("5551234567", profile.getPhoneNumber());
+        assertEquals("nick@test.com", profile.getEmail());
+    }
+
+    @Test
+    public void testConstructorRejectsBlankName() {
+        try {
+            new CustomerProfile("   ");
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Name cannot be empty.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUpdatePersonalInformationTrimsValues() {
+        CustomerProfile profile = new CustomerProfile("Nick");
+
+        profile.updatePersonalInformation(" 123 Main St ", " 5551234567 ", " nick@test.com ");
+
+        assertEquals("123 Main St", profile.getAddress());
+        assertEquals("5551234567", profile.getPhoneNumber());
+        assertEquals("nick@test.com", profile.getEmail());
+    }
+
+    @Test
+    public void testUpdatePersonalInformationRejectsBlankEmail() {
+        CustomerProfile profile = new CustomerProfile("Nick");
+
+        try {
+            profile.updatePersonalInformation("123 Main St", "5551234567", " ");
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Email cannot be empty.", e.getMessage());
+        }
+    }
+}

--- a/src/test/CustomerRegistrationRequestTest.java
+++ b/src/test/CustomerRegistrationRequestTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/CustomerRegistrationRequestTest.java
+++ b/src/test/CustomerRegistrationRequestTest.java
@@ -1,0 +1,27 @@
+package main;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CustomerRegistrationRequestTest {
+
+    @Test
+    public void testGettersReturnProvidedValues() {
+        CustomerRegistrationRequest request = new CustomerRegistrationRequest(
+                "Nick",
+                "123 Main St",
+                "5551234567",
+                "nick@test.com",
+                "password123",
+                "1234"
+        );
+
+        assertEquals("Nick", request.getName());
+        assertEquals("123 Main St", request.getAddress());
+        assertEquals("5551234567", request.getPhoneNumber());
+        assertEquals("nick@test.com", request.getEmail());
+        assertEquals("password123", request.getPassword());
+        assertEquals("1234", request.getPin());
+    }
+}

--- a/src/test/CustomerRegistrationServiceTest.java
+++ b/src/test/CustomerRegistrationServiceTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/CustomerSnapshotTest.java
+++ b/src/test/CustomerSnapshotTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import java.time.LocalDate;

--- a/src/test/FeeSnapshotTest.java
+++ b/src/test/FeeSnapshotTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import java.util.Date;

--- a/src/test/MenuInputTest.java
+++ b/src/test/MenuInputTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;

--- a/src/test/MonthlyStatementViewerTest.java
+++ b/src/test/MonthlyStatementViewerTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;

--- a/src/test/MonthlyStatementViewerTest.java
+++ b/src/test/MonthlyStatementViewerTest.java
@@ -1,0 +1,88 @@
+package main;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MonthlyStatementViewerTest {
+
+    private static final int CURRENT_YEAR = java.time.LocalDate.now().getYear();
+    private static final int CURRENT_MONTH = java.time.LocalDate.now().getMonthValue();
+
+    private String runViewer(BankAccount account, String input) {
+        Scanner scanner = new Scanner(new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
+        MonthlyStatementViewer viewer = new MonthlyStatementViewer(scanner, account);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        try {
+            System.setOut(new PrintStream(output));
+            viewer.viewMonthlyStatement();
+        } finally {
+            System.setOut(original);
+        }
+        return output.toString();
+    }
+
+    @Test
+    public void testNoTransactionsShowsNotFoundMessage() {
+        BankAccount account = new BankAccount();
+        String input = CURRENT_YEAR + System.lineSeparator() + CURRENT_MONTH + System.lineSeparator();
+
+        String output = runViewer(account, input);
+
+        assertTrue(output.contains("No transactions found for"));
+    }
+
+    @Test
+    public void testTransactionsInQueriedMonthAreDisplayed() {
+        BankAccount account = new BankAccount();
+        account.deposit(200.0);
+        account.withdraw(50.0);
+        String input = CURRENT_YEAR + System.lineSeparator() + CURRENT_MONTH + System.lineSeparator();
+
+        String output = runViewer(account, input);
+
+        assertTrue(output.contains("Deposited: 200.0"));
+        assertTrue(output.contains("Withdrew: 50.0"));
+    }
+
+    @Test
+    public void testTransactionsOutsideQueriedMonthAreExcluded() {
+        BankAccount account = new BankAccount();
+        account.deposit(100.0);
+
+        int otherMonth = (CURRENT_MONTH % 12) + 1;
+        int otherYear = otherMonth == 1 ? CURRENT_YEAR + 1 : CURRENT_YEAR;
+        String input = otherYear + System.lineSeparator() + otherMonth + System.lineSeparator();
+
+        String output = runViewer(account, input);
+
+        assertFalse(output.contains("Deposited: 100.0"));
+        assertTrue(output.contains("No transactions found for"));
+    }
+
+    @Test
+    public void testSummaryShowsCreditsDebitsAndNetChange() {
+        BankAccount account = new BankAccount();
+        account.deposit(300.0);
+        account.withdraw(80.0);
+        String input = CURRENT_YEAR + System.lineSeparator() + CURRENT_MONTH + System.lineSeparator();
+
+        String output = runViewer(account, input);
+
+        assertTrue(output.contains("Total credits:"));
+        assertTrue(output.contains("Total debits:"));
+        assertTrue(output.contains("Net change:"));
+        assertTrue(output.contains("300.0"));
+        assertTrue(output.contains("80.0"));
+        assertTrue(output.contains("220.0"));
+    }
+}

--- a/src/test/RecurringPaymentMenuTest.java
+++ b/src/test/RecurringPaymentMenuTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;

--- a/src/test/RecurringPaymentSnapshotTest.java
+++ b/src/test/RecurringPaymentSnapshotTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import java.time.LocalDate;

--- a/src/test/TransactionTest.java
+++ b/src/test/TransactionTest.java
@@ -1,5 +1,6 @@
-package main;
+package test;
 
+import main.*;
 import org.junit.Test;
 
 import java.time.LocalDate;

--- a/src/test/TransactionTest.java
+++ b/src/test/TransactionTest.java
@@ -1,0 +1,41 @@
+package main;
+
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class TransactionTest {
+
+    @Test
+    public void testTransactionStoresValuesAndFormatsOutput() {
+        Transaction transaction = new Transaction(LocalDate.of(2026, 4, 21), "Deposited: 50.0", 50.0);
+
+        assertEquals(LocalDate.of(2026, 4, 21), transaction.getDate());
+        assertEquals("Deposited: 50.0", transaction.getDescription());
+        assertEquals(50.0, transaction.getAmount(), 0.001);
+        assertEquals("2026-04-21 | Deposited: 50.0 | $50.0", transaction.toString());
+    }
+
+    @Test
+    public void testConstructorRejectsNullDate() {
+        try {
+            new Transaction(null, "Deposited: 50.0", 50.0);
+            fail();
+        } catch (NullPointerException e) {
+            assertEquals("date cannot be null.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testConstructorRejectsNullDescription() {
+        try {
+            new Transaction(LocalDate.of(2026, 4, 21), null, 50.0);
+            fail();
+        } catch (NullPointerException e) {
+            assertEquals("description cannot be null.", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Customers can now view a filtered statement for any month from the account sub-menu (option 8). Adds a structured Transaction list to BankAccount so each operation is date-stamped, persisted via AccountSnapshot, and displayed with a credit/debit summary by MonthlyStatementViewer.